### PR TITLE
Fix super like functionality and animation issues

### DIFF
--- a/Services/MatchService.swift
+++ b/Services/MatchService.swift
@@ -115,6 +115,12 @@ class MatchService {
         } catch {
             // Restore super like if API call failed
             superLikesRemaining += 1
+            
+            // Also reset cooldown if we're restoring a super like
+            if superLikesRemaining > 0 {
+                nextSuperLikeAvailable = Date()
+            }
+            
             saveSuperLikeState()
             self.error = error
         }

--- a/Views/Match/MatchCardView.swift
+++ b/Views/Match/MatchCardView.swift
@@ -358,6 +358,9 @@ struct MatchCardView: View {
                     // Check for super like (swipe up)
                     if gesture.translation.height < -threshold && canUseSuperLike {
                         showingSuperLikeAnimation = true
+                        // Reset card position like other gesture endings
+                        offset = .zero
+                        rotation = 0
                     }
                     // Check for horizontal swipes
                     else if abs(gesture.translation.width) > threshold {


### PR DESCRIPTION
*   In `Services/MatchService.swift`, within the `superLike()` method's error handling, `nextSuperLikeAvailable` is now reset to the current date if `superLikesRemaining` is restored after an API failure. This ensures that the cooldown is properly cleared, allowing users to immediately use their restored super likes.
*   In `Views/Match/MatchCardView.swift`, the `onEnded` handler for the vertical swipe gesture was updated. When a super like is triggered, the card's `offset` is set to `.zero` and `rotation` to `0`. This ensures the card returns to its default position before the super like animation, preventing visual displacement and aligning with other card interaction behaviors.